### PR TITLE
Managed state directories & non-root runtime user for containers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -215,6 +215,22 @@
         "url": "ssh://git@github.com/pedorich-n/home-server-nixos-secrets"
       }
     },
+    "homeassistant-docker-venv": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1730991426,
+        "narHash": "sha256-zxpmnzWIv4JIRftFZtnGDzA8uMSR4OiQLlEadfyDpoM=",
+        "owner": "tribut",
+        "repo": "homeassistant-docker-venv",
+        "rev": "5ffd91eb641a2ffeaef3a84aaa5b61eed169a8ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tribut",
+        "repo": "homeassistant-docker-venv",
+        "type": "github"
+      }
+    },
     "jinja2-renderer": {
       "inputs": {
         "flake-parts": [
@@ -510,6 +526,7 @@
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
         "home-server-nixos-secrets": "home-server-nixos-secrets",
+        "homeassistant-docker-venv": "homeassistant-docker-venv",
         "jinja2-renderer": "jinja2-renderer",
         "minecraft-modpack": "minecraft-modpack",
         "nix-minecraft": "nix-minecraft",

--- a/flake.nix
+++ b/flake.nix
@@ -169,9 +169,13 @@
       };
     };
 
-
     trash-guides = {
       url = "github:TRaSH-Guides/Guides";
+      flake = false;
+    };
+
+    homeassistant-docker-venv = {
+      url = "github:tribut/homeassistant-docker-venv";
       flake = false;
     };
   };

--- a/machines/geekomA5/modules/system/hardware/udev.nix
+++ b/machines/geekomA5/modules/system/hardware/udev.nix
@@ -1,9 +1,9 @@
-{
+{ config, ... }: {
   services.udev = {
     enable = true;
     # Use `udevadm info -a /dev/XXX` or `lsusb -v` to get those attrs
     extraRules = '' 
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0664", GROUP="zigbee"
+      SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0664", GROUP="${config.users.groups.zigbee.name}"
     '';
   };
 }

--- a/machines/geekomA5/modules/system/services/authentik/containers.nix
+++ b/machines/geekomA5/modules/system/services/authentik/containers.nix
@@ -1,5 +1,7 @@
 { config, containerLib, systemdLib, jinja2RendererLib, ... }:
 let
+  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+
   storeFor = localPath: remotePath: "/mnt/store/server-management/authentik/${localPath}:${remotePath}";
 
   defaultEnvs = {
@@ -33,12 +35,11 @@ in
 
         containerConfig = {
           environments = defaultEnvs;
-          user = "root";
           environmentFiles = [ config.age.secrets.authentik.path ];
           volumes = [
             (storeFor "postgresql" "/var/lib/postgresql/data")
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
@@ -47,11 +48,10 @@ in
 
         containerConfig = {
           exec = "--save 60 1 --loglevel warning";
-          user = "root";
           volumes = [
             (storeFor "redis" "/data")
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
@@ -59,7 +59,6 @@ in
         useGlobalContainers = true;
         containerConfig = {
           exec = "worker";
-          user = "root";
           healthCmd = "ak healthcheck";
           healthStartPeriod = "20s";
           healthTimeout = "5s";
@@ -72,7 +71,7 @@ in
             (storeFor "media" "/media")
             "${blueprints}:/blueprints/custom"
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
 
         unitConfig = systemdLib.requiresAfter
@@ -105,7 +104,7 @@ in
             "traefik.tcp.routers.authentik-ldap-outpost.entrypoints=ldap"
             "traefik.tcp.routers.authentik-ldap-outpost.service=authentik-ldap-outpost"
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
@@ -113,7 +112,6 @@ in
         useGlobalContainers = true;
         containerConfig = {
           exec = "server";
-          user = "root";
           environments = defaultEnvs;
           environmentFiles = [ config.age.secrets.authentik.path ];
           volumes = [
@@ -142,7 +140,7 @@ in
             "traefik.http.middlewares.authentik.forwardauth.trustForwardHeader=true"
             "traefik.http.middlewares.authentik.forwardauth.authResponseHeaders=X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid,X-authentik-jwt,X-authentik-meta-jwks,X-authentik-meta-outpost,X-authentik-meta-provider,X-authentik-meta-app,X-authentik-meta-version"
           ];
-          inherit pod;
+          inherit pod user;
         };
 
         unitConfig = systemdLib.requiresAfter

--- a/machines/geekomA5/modules/system/services/authentik/containers.nix
+++ b/machines/geekomA5/modules/system/services/authentik/containers.nix
@@ -1,6 +1,6 @@
 { config, containerLib, systemdLib, jinja2RendererLib, ... }:
 let
-  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${builtins.toString config.users.users.user.uid}:${builtins.toString config.users.groups.${config.users.users.user.group}.gid}";
 
   storeFor = localPath: remotePath: "/mnt/store/server-management/authentik/${localPath}:${remotePath}";
 

--- a/machines/geekomA5/modules/system/services/authentik/folders.nix
+++ b/machines/geekomA5/modules/system/services/authentik/folders.nix
@@ -1,0 +1,38 @@
+{ config, lib, ... }:
+let
+  storeRoot = "/mnt/store/server-management/authentik";
+
+  defaultRules = {
+    user = config.users.users.user.name;
+    group = config.users.users.user.group;
+    mode = "0755";
+  };
+
+  mkCreateDirectoryRule = {
+    "d" = defaultRules; # Create a directory
+  };
+
+  mkSetPermissionsRule = {
+    "Z" = defaultRules; # Set mode/permissions recursively to a directory, in case it already exists
+  };
+
+  foldersToCreate =
+    lib.map (folder: "${storeRoot}/${folder}") [
+      "media"
+      "maloja/data"
+
+      "postgres"
+
+      "redis"
+    ];
+
+  foldersToSetPermissions = [
+    storeRoot
+  ];
+in
+{
+  systemd.tmpfiles.settings = {
+    "90-authentik-create" = lib.foldl' (acc: folder: acc // { ${folder} = mkCreateDirectoryRule; }) { } foldersToCreate;
+    "91-authentik-set" = lib.foldl' (acc: folder: acc // { ${folder} = mkSetPermissionsRule; }) { } foldersToSetPermissions;
+  };
+}

--- a/machines/geekomA5/modules/system/services/data-library/containers.nix
+++ b/machines/geekomA5/modules/system/services/data-library/containers.nix
@@ -13,7 +13,7 @@ let
     priority = 15;
   };
 
-  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${builtins.toString config.users.users.user.uid}:${builtins.toString config.users.groups.${config.users.users.user.group}.gid}";
 
   defaultEnvs = {
     TZ = "${config.time.timeZone}";

--- a/machines/geekomA5/modules/system/services/data-library/containers.nix
+++ b/machines/geekomA5/modules/system/services/data-library/containers.nix
@@ -165,6 +165,9 @@ in
             TZ = "${config.time.timeZone}";
           };
           notify = "healthy"; # This image has working healthcheck already, so I just need to connect it to systemd
+          addGroups = [
+            (builtins.toString config.users.groups.render.gid) # For HW Transcoding
+          ];
           devices = [
             # HW Transcoding acceleration. 
             # See https://jellyfin.org/docs/general/installation/container#with-hardware-acceleration

--- a/machines/geekomA5/modules/system/services/data-library/containers.nix
+++ b/machines/geekomA5/modules/system/services/data-library/containers.nix
@@ -13,13 +13,17 @@ let
     priority = 15;
   };
 
+  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+
   defaultEnvs = {
     TZ = "${config.time.timeZone}";
+  };
+
+  PUID_GUID = {
     PUID = builtins.toString config.users.users.user.uid;
     PGID = builtins.toString config.users.groups.${config.users.users.user.group}.gid;
   };
 
-  user = "${defaultEnvs.PUID}:${defaultEnvs.PGID}";
 in
 {
   virtualisation.quadlet = {
@@ -70,7 +74,7 @@ in
           # Broken until https://github.com/containers/podman/pull/24794 is released
           # networks = [ "gluetun.container" ];
           networks = [ "container:gluetun" ];
-          inherit pod;
+          inherit pod user;
         };
 
         unitConfig = systemdLib.requiresAfter [ "gluetun.service" ] { };
@@ -93,7 +97,7 @@ in
             port = environments.PORT;
             middlewares = [ "authentik@docker" ];
           };
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
@@ -112,7 +116,7 @@ in
             priority = 10;
             middlewares = [ "authentik@docker" ];
           }) ++ (mkArrApiTraefikLabels "prowlarr");
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
@@ -120,8 +124,9 @@ in
         requiresTraefikNetwork = true;
         useGlobalContainers = true;
 
+        # TODO: get rid of PUID/GUID with the next release as it should support `user` now. 
         containerConfig = {
-          environments = defaultEnvs;
+          environments = defaultEnvs // PUID_GUID;
           volumes = [
             (storeFor "sonarr/config" "/config")
             (externalStoreFor "" "/data")
@@ -152,7 +157,7 @@ in
             priority = 10;
             middlewares = [ "authentik@docker" ];
           }) ++ (mkArrApiTraefikLabels "radarr");
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
@@ -161,9 +166,6 @@ in
         useGlobalContainers = true;
 
         containerConfig = {
-          environments = {
-            TZ = "${config.time.timeZone}";
-          };
           notify = "healthy"; # This image has working healthcheck already, so I just need to connect it to systemd
           addGroups = [
             (builtins.toString config.users.groups.render.gid) # For HW Transcoding
@@ -174,7 +176,7 @@ in
             # See https://jellyfin.org/docs/general/administration/hardware-acceleration/amd#linux-setups
             "/dev/dri:/dev/dri"
           ];
-          environments = {
+          environments = defaultEnvs // {
             JELLYFIN_PublishedServerUrl = "http://jellyfin.${config.custom.networking.domain}";
           };
           volumes = [
@@ -200,8 +202,7 @@ in
         useGlobalContainers = true;
 
         containerConfig = containerLib.withAlpineHostsFix rec {
-          environments = {
-            TZ = "${config.time.timeZone}";
+          environments = defaultEnvs // {
             PORT = "8080";
           };
           healthCmd = "curl http://localhost:${environments.PORT}/healthcheck";

--- a/machines/geekomA5/modules/system/services/grist/containers.nix
+++ b/machines/geekomA5/modules/system/services/grist/containers.nix
@@ -1,5 +1,6 @@
 { config, containerLib, authentikLib, ... }:
 let
+  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
   storeFor = localPath: remotePath: "/mnt/store/grist/${localPath}:${remotePath}";
 in
 {
@@ -25,6 +26,7 @@ in
         (storeFor "persist" "/persist")
       ];
       labels = containerLib.mkTraefikLabels { name = "grist"; port = 8484; };
+      inherit user;
     };
   };
 

--- a/machines/geekomA5/modules/system/services/grist/containers.nix
+++ b/machines/geekomA5/modules/system/services/grist/containers.nix
@@ -1,6 +1,6 @@
 { config, containerLib, authentikLib, ... }:
 let
-  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${builtins.toString config.users.users.user.uid}:${builtins.toString config.users.groups.${config.users.users.user.group}.gid}";
   storeFor = localPath: remotePath: "/mnt/store/grist/${localPath}:${remotePath}";
 in
 {

--- a/machines/geekomA5/modules/system/services/grist/folders.nix
+++ b/machines/geekomA5/modules/system/services/grist/folders.nix
@@ -1,0 +1,33 @@
+{ config, lib, ... }:
+let
+  storeRoot = "/mnt/store/grist";
+
+  defaultRules = {
+    user = config.users.users.user.name;
+    group = config.users.users.user.group;
+    mode = "0755";
+  };
+
+  mkCreateDirectoryRule = {
+    "d" = defaultRules; # Create a directory
+  };
+
+  mkSetPermissionsRule = {
+    "Z" = defaultRules; # Set mode/permissions recursively to a directory, in case it already exists
+  };
+
+  foldersToCreate =
+    lib.map (folder: "${storeRoot}/${folder}") [
+      "persist"
+    ];
+
+  foldersToSetPermissions = [
+    storeRoot
+  ];
+in
+{
+  systemd.tmpfiles.settings = {
+    "90-grist-create" = lib.foldl' (acc: folder: acc // { ${folder} = mkCreateDirectoryRule; }) { } foldersToCreate;
+    "91-grist-set" = lib.foldl' (acc: folder: acc // { ${folder} = mkSetPermissionsRule; }) { } foldersToSetPermissions;
+  };
+}

--- a/machines/geekomA5/modules/system/services/home-automation/containers.nix
+++ b/machines/geekomA5/modules/system/services/home-automation/containers.nix
@@ -1,6 +1,6 @@
 { inputs, config, pkgs, containerLib, systemdLib, ... }:
 let
-  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${builtins.toString config.users.users.user.uid}:${builtins.toString config.users.groups.${config.users.users.user.group}.gid}";
   PUID_GUID = {
     PUID = builtins.toString config.users.users.user.uid;
     PGID = builtins.toString config.users.groups.${config.users.users.user.group}.gid;

--- a/machines/geekomA5/modules/system/services/home-automation/folders.nix
+++ b/machines/geekomA5/modules/system/services/home-automation/folders.nix
@@ -1,0 +1,43 @@
+{ config, lib, ... }:
+let
+  storeRoot = "/mnt/store/home-automation";
+
+  defaultRules = {
+    user = config.users.users.user.name;
+    group = config.users.users.user.group;
+    mode = "0755";
+  };
+
+  mkCreateDirectoryRule = {
+    "d" = defaultRules; # Create a directory
+  };
+
+  mkSetPermissionsRule = {
+    "Z" = defaultRules; # Set mode/permissions recursively to a directory, in case it already exists
+  };
+
+  foldersToCreate =
+    lib.map (folder: "${storeRoot}/${folder}") [
+      "homeassistant"
+
+      "mosquitto"
+      "mosquitto/data"
+      "mosquitto/log"
+
+      "nodered"
+
+      "postgresql"
+
+      "zigbee2mqtt"
+    ];
+
+  foldersToSetPermissions = [
+    storeRoot
+  ];
+in
+{
+  systemd.tmpfiles.settings = {
+    "90-home-automation-create" = lib.foldl' (acc: folder: acc // { ${folder} = mkCreateDirectoryRule; }) { } foldersToCreate;
+    "91-home-automation-set" = lib.foldl' (acc: folder: acc // { ${folder} = mkSetPermissionsRule; }) { } foldersToSetPermissions;
+  };
+}

--- a/machines/geekomA5/modules/system/services/home-automation/homeassistant/static/configuration.yaml
+++ b/machines/geekomA5/modules/system/services/home-automation/homeassistant/static/configuration.yaml
@@ -31,7 +31,6 @@ recorder:
   db_url: !secret db_url
 
 http:
-  server_port: 80
   use_x_forwarded_for: true
   trusted_proxies:
     - 172.31.0.0/24 #LINK - machines/geekomA5/modules/system/services/traefik/podman-traefik-network.nix

--- a/machines/geekomA5/modules/system/services/immich/containers.nix
+++ b/machines/geekomA5/modules/system/services/immich/containers.nix
@@ -1,6 +1,6 @@
 { config, containerLib, systemdLib, ... }:
 let
-  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${builtins.toString config.users.users.user.uid}:${builtins.toString config.users.groups.${config.users.users.user.group}.gid}";
 
   storeFor = localPath: remotePath: "/mnt/store/immich/${localPath}:${remotePath}";
 

--- a/machines/geekomA5/modules/system/services/immich/containers.nix
+++ b/machines/geekomA5/modules/system/services/immich/containers.nix
@@ -1,6 +1,6 @@
 { config, containerLib, systemdLib, ... }:
 let
-  userSetting = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
 
   storeFor = localPath: remotePath: "/mnt/store/immich/${localPath}:${remotePath}";
 
@@ -49,34 +49,31 @@ in
         containerConfig = {
           image = "registry.hub.docker.com/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0";
           environments = sharedEnvs;
-          user = userSetting;
           environmentFiles = [ config.age.secrets.immich.path ];
           volumes = [
             (storeFor "postgresql" "/var/lib/postgresql/data")
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
       immich-redis = {
         containerConfig = {
           image = "registry.hub.docker.com/library/redis:6.2-alpine@sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672";
-          user = userSetting;
           volumes = [
             (storeFor "redis" "/data")
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
       immich-machine-learning = {
         useGlobalContainers = true;
         containerConfig = {
-          user = userSetting;
           volumes = [
             (storeFor "cache/machine-learning" "/cache")
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
 
         unitConfig = systemdLib.requiresAfter
@@ -95,7 +92,6 @@ in
         containerConfig = {
           environments = sharedEnvs;
           environmentFiles = [ config.age.secrets.immich.path ];
-          user = userSetting;
           addGroups = [
             (builtins.toString config.users.groups.render.gid) # For HW Transcoding
           ];
@@ -107,7 +103,7 @@ in
             (containerLib.mkTraefikLabels { name = "immich"; port = 2283; }) ++
             (containerLib.mkTraefikMetricsLabels { name = "immich"; port = 8081; addPath = "/metrics"; }) ++
             (containerLib.mkTraefikMetricsLabels { name = "immich-microservices"; port = 8082; addPath = "/metrics"; });
-          inherit networks pod;
+          inherit networks pod user;
         };
 
         unitConfig = systemdLib.requiresAfter

--- a/machines/geekomA5/modules/system/services/immich/folders.nix
+++ b/machines/geekomA5/modules/system/services/immich/folders.nix
@@ -1,0 +1,46 @@
+{ config, lib, ... }:
+let
+  storeRoot = "/mnt/store/immich";
+  externalRoot = "/mnt/external/immich-library";
+
+  defaultRules = {
+    user = config.users.users.user.name;
+    group = config.users.users.user.group;
+    mode = "0755";
+  };
+
+  mkCreateDirectoryRule = {
+    "d" = defaultRules; # Create a directory
+  };
+
+  mkSetPermissionsRule = {
+    "Z" = defaultRules; # Set mode/permissions recursively to a directory, in case it already exists
+  };
+
+  foldersToCreate =
+    lib.map (folder: "${storeRoot}/${folder}") [
+      "cache"
+      "cache/thumbnails"
+      "cache/profile"
+      "cache/machine-learning"
+
+      # "machine-learning"
+      # "machine-learning/.cache"
+      # "machine-learning/.config"
+
+      "postgresql"
+
+      "redis"
+    ];
+
+  foldersToSetPermissions = [
+    storeRoot
+    externalRoot
+  ];
+in
+{
+  systemd.tmpfiles.settings = {
+    "90-immich-create" = lib.foldl' (acc: folder: acc // { ${folder} = mkCreateDirectoryRule; }) { } foldersToCreate;
+    "91-immich-set" = lib.foldl' (acc: folder: acc // { ${folder} = mkSetPermissionsRule; }) { } foldersToSetPermissions;
+  };
+}

--- a/machines/geekomA5/modules/system/services/music-history/containers.nix
+++ b/machines/geekomA5/modules/system/services/music-history/containers.nix
@@ -1,5 +1,11 @@
 { config, containerLib, pkgs, ... }:
 let
+  # Those images are built on linuxserver.io images so they need PUID/PGID instead of `--user uid:gid` :(
+  defaultEnvs = {
+    PUID = builtins.toString config.users.users.user.uid;
+    PGID = builtins.toString config.users.groups.${config.users.users.user.group}.gid;
+  };
+
   storeFor = localPath: remotePath: "/mnt/store/music-history/${localPath}:${remotePath}";
 
   malojaArtistRules = pkgs.callPackage ./maloja/_artist-rules.nix { };
@@ -22,7 +28,7 @@ in
         useGlobalContainers = true;
 
         containerConfig = {
-          environments = {
+          environments = defaultEnvs // {
             TZ = config.time.timeZone;
 
             BASE_URL = "http://multiscrobbler.${config.custom.networking.domain}:80";
@@ -50,7 +56,7 @@ in
         useGlobalContainers = true;
 
         containerConfig = {
-          environments = {
+          environments = defaultEnvs // {
             MALOJA_SKIP_SETUP = "true";
             MALOJA_SEND_STATS = "false";
             MALOJA_SCROBBLE_LASTFM = "false";

--- a/machines/geekomA5/modules/system/services/music-history/folders.nix
+++ b/machines/geekomA5/modules/system/services/music-history/folders.nix
@@ -1,0 +1,37 @@
+{ config, lib, ... }:
+let
+  storeRoot = "/mnt/store/music-history";
+
+  defaultRules = {
+    user = config.users.users.user.name;
+    group = config.users.users.user.group;
+    mode = "0755";
+  };
+
+  mkCreateDirectoryRule = {
+    "d" = defaultRules; # Create a directory
+  };
+
+  mkSetPermissionsRule = {
+    "Z" = defaultRules; # Set mode/permissions recursively to a directory, in case it already exists
+  };
+
+  foldersToCreate =
+    lib.map (folder: "${storeRoot}/${folder}") [
+      "maloja"
+      "maloja/data"
+
+      "multi-scrobbler"
+      "multi-scrobbler/config"
+    ];
+
+  foldersToSetPermissions = [
+    storeRoot
+  ];
+in
+{
+  systemd.tmpfiles.settings = {
+    "90-music-history-create" = lib.foldl' (acc: folder: acc // { ${folder} = mkCreateDirectoryRule; }) { } foldersToCreate;
+    "91-music-history-set" = lib.foldl' (acc: folder: acc // { ${folder} = mkSetPermissionsRule; }) { } foldersToSetPermissions;
+  };
+}

--- a/machines/geekomA5/modules/system/services/paperless/containers.nix
+++ b/machines/geekomA5/modules/system/services/paperless/containers.nix
@@ -1,6 +1,6 @@
 { config, containerLib, systemdLib, ... }:
 let
-  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${builtins.toString config.users.users.user.uid}:${builtins.toString config.users.groups.${config.users.users.user.group}.gid}";
 
   storeFor = localPath: remotePath: "/mnt/store/paperless/${localPath}:${remotePath}";
   externalStoreFor = localPath: remotePath: "/mnt/external/paperless-library/${localPath}:${remotePath}";

--- a/machines/geekomA5/modules/system/services/paperless/containers.nix
+++ b/machines/geekomA5/modules/system/services/paperless/containers.nix
@@ -1,6 +1,6 @@
 { config, containerLib, systemdLib, ... }:
 let
-  userSetting = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+  user = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
 
   storeFor = localPath: remotePath: "/mnt/store/paperless/${localPath}:${remotePath}";
   externalStoreFor = localPath: remotePath: "/mnt/external/paperless-library/${localPath}:${remotePath}";
@@ -21,11 +21,10 @@ in
         useGlobalContainers = true;
 
         containerConfig = {
-          user = userSetting;
           volumes = [
             (storeFor "redis" "/data")
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 
@@ -34,11 +33,10 @@ in
 
         containerConfig = {
           environmentFiles = [ config.age.secrets.paperless.path ];
-          user = userSetting;
           volumes = [
             (storeFor "postgresql" "/var/lib/postgresql/data")
           ];
-          inherit networks pod;
+          inherit networks pod user;
         };
       };
 

--- a/machines/geekomA5/modules/system/services/paperless/containers.nix
+++ b/machines/geekomA5/modules/system/services/paperless/containers.nix
@@ -1,5 +1,7 @@
 { config, containerLib, systemdLib, ... }:
 let
+  userSetting = "${toString config.users.users.user.uid}:${toString config.users.groups.${config.users.users.user.group}.gid}";
+
   storeFor = localPath: remotePath: "/mnt/store/paperless/${localPath}:${remotePath}";
   externalStoreFor = localPath: remotePath: "/mnt/external/paperless-library/${localPath}:${remotePath}";
 
@@ -19,6 +21,7 @@ in
         useGlobalContainers = true;
 
         containerConfig = {
+          user = userSetting;
           volumes = [
             (storeFor "redis" "/data")
           ];
@@ -31,6 +34,7 @@ in
 
         containerConfig = {
           environmentFiles = [ config.age.secrets.paperless.path ];
+          user = userSetting;
           volumes = [
             (storeFor "postgresql" "/var/lib/postgresql/data")
           ];
@@ -45,6 +49,9 @@ in
 
         containerConfig = {
           environments = {
+            USERMAP_UID = builtins.toString config.users.users.user.uid;
+            USERMAP_GID = builtins.toString config.users.groups.${config.users.users.user.group}.gid;
+
             PAPERLESS_DBHOST = "paperless-postgresql";
             PAPERLESS_DBENGINE = "postgres";
             PAPERLESS_REDIS = "redis://paperless-redis:6379";

--- a/machines/geekomA5/modules/system/services/paperless/folders.nix
+++ b/machines/geekomA5/modules/system/services/paperless/folders.nix
@@ -1,0 +1,43 @@
+{ config, lib, ... }:
+let
+  storeRoot = "/mnt/store/paperless";
+  externalRoot = "/mnt/external/paperless-library";
+
+  defaultRules = {
+    user = config.users.users.user.name;
+    group = config.users.users.user.group;
+    mode = "0755";
+  };
+
+  mkCreateDirectoryRule = {
+    "d" = defaultRules; # Create a directory
+  };
+
+  mkSetPermissionsRule = {
+    "Z" = defaultRules; # Set mode/permissions recursively to a directory, in case it already exists
+  };
+
+  foldersToCreate =
+    (lib.map (folder: "${storeRoot}/${folder}") [
+      "data"
+
+      "export"
+
+      "postgresql"
+
+      "redis"
+    ]) ++ (lib.map (folder: "${externalRoot}/${folder}") [
+      "media"
+    ]);
+
+  foldersToSetPermissions = [
+    storeRoot
+    externalRoot
+  ];
+in
+{
+  systemd.tmpfiles.settings = {
+    "90-paperless-create" = lib.foldl' (acc: folder: acc // { ${folder} = mkCreateDirectoryRule; }) { } foldersToCreate;
+    "91-paperless-set" = lib.foldl' (acc: folder: acc // { ${folder} = mkSetPermissionsRule; }) { } foldersToSetPermissions;
+  };
+}

--- a/machines/geekomA5/modules/system/services/paperless/restic-backup.nix
+++ b/machines/geekomA5/modules/system/services/paperless/restic-backup.nix
@@ -20,7 +20,7 @@ in
 
       backupPrepareCommand = ''
         ${lib.getExe config.virtualisation.podman.package} exec --tty paperless-server \
-        document_exporter /usr/src/paperless/export --delete
+        gosu paperless document_exporter /usr/src/paperless/export --delete
       '';
 
       backupCleanupCommand = ''

--- a/machines/geekomA5/modules/system/users.nix
+++ b/machines/geekomA5/modules/system/users.nix
@@ -1,7 +1,9 @@
 { config, lib, pkgs, ... }: {
   users = {
     groups = {
-      zigbee = { };
+      zigbee = {
+        gid = 992; # Was set by the activation script before I needed to know it in build-time
+      };
     };
 
     users = {

--- a/versions/containers.json
+++ b/versions/containers.json
@@ -130,29 +130,29 @@
     "version": "2.25.1"
   },
   "prowlarr": {
-    "container": "hotio/prowlarr",
-    "registry": "ghcr.io",
-    "version": "release-1.28.2.4885"
+    "container": "linuxserver/prowlarr",
+    "registry": "docker.io",
+    "version": "1.29.2"
   },
   "qbittorrent": {
     "container": "linuxserver/qbittorrent",
     "registry": "docker.io",
-    "version": "20.04.1"
+    "version": "5.0.3"
   },
   "radarr": {
-    "container": "hotio/radarr",
-    "registry": "ghcr.io",
-    "version": "release-5.16.3.9541"
+    "container": "linuxserver/radarr",
+    "registry": "docker.io",
+    "version": "5.17.2"
   },
   "sabnzbd": {
     "container": "linuxserver/sabnzbd",
-    "registry": "lscr.io",
+    "registry": "docker.io",
     "version": "4.4.1"
   },
   "sonarr": {
-    "container": "hotio/sonarr",
-    "registry": "ghcr.io",
-    "version": "release-4.0.11.2680"
+    "container": "linuxserver/sonarr",
+    "registry": "docker.io",
+    "version": "4.0.12"
   },
   "zigbee2mqtt": {
     "container": "koenkk/zigbee2mqtt",


### PR DESCRIPTION
Manage state directories for most of the services using `tmpfiles` and run most of the containers with non-root user.