### PR TITLE
Yet another ZFS rework

### DIFF
--- a/machines/geekomA5/modules/system/hardware/filesystems/zfs-external.nix
+++ b/machines/geekomA5/modules/system/hardware/filesystems/zfs-external.nix
@@ -1,6 +1,9 @@
 {
   # NOTE: https://wiki.archlinux.org/title/ZFS
 
+  # LINK https://github.com/nix-community/disko/issues/581#issuecomment-2260602290
+  boot.zfs.extraPools = [ "external" ];
+
   disko.devices = {
     disk = {
       external_1 = {
@@ -45,8 +48,6 @@
           "com.sun:auto-snapshot" = "false"; # Don't take snapshots of root
         };
 
-        mountpoint = "/mnt/external"; # fstab mountpoint
-
         datasets = {
           immich = {
             type = "zfs_fs";
@@ -55,7 +56,6 @@
               recordsize = "1M"; # Better read performance for "large" files like images, videos, etc.
               "com.sun:auto-snapshot" = "true";
             };
-            mountpoint = "/mnt/external/immich-library"; # fstab mountpoint
           };
 
           paperless = {
@@ -65,7 +65,6 @@
               quota = "10G";
               "com.sun:auto-snapshot" = "true";
             };
-            mountpoint = "/mnt/external/paperless-library";
           };
 
           data = {
@@ -76,7 +75,6 @@
               recordsize = "1M"; # Better read performance for "large" files like images, videos, etc.
               "com.sun:auto-snapshot" = "true";
             };
-            mountpoint = "/mnt/external/data-library"; # fstab mountpoint
           };
 
           object-storage = {
@@ -86,38 +84,9 @@
               quota = "500G";
               "com.sun:auto-snapshot" = "true";
             };
-            mountpoint = "/mnt/external/object-storage"; # fstab mountpoint
           };
         };
       };
     };
-  };
-
-  # NOTE https://github.com/nix-community/disko/issues/581
-  fileSystems = {
-    "/mnt/external".options = [
-      "nofail"
-      "noauto"
-    ];
-
-    "/mnt/external/immich-library".options = [
-      "nofail"
-      "noauto"
-    ];
-
-    "/mnt/external/paperless-library".options = [
-      "nofail"
-      "noauto"
-    ];
-
-    "/mnt/external/data-library".options = [
-      "nofail"
-      "noauto"
-    ];
-
-    "/mnt/external/object-storage".options = [
-      "nofail"
-      "noauto"
-    ];
   };
 }

--- a/machines/geekomA5/modules/system/services/data-library/containers.nix
+++ b/machines/geekomA5/modules/system/services/data-library/containers.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   containerLib,
   systemdLib,
   networkingLib,
@@ -112,6 +113,7 @@ in
 
         unitConfig = systemdLib.bindsToAfter [
           containers.gluetun.ref
+          "zfs.target"
         ];
       };
 
@@ -139,6 +141,10 @@ in
           inherit networks;
           inherit (containerLib.containerIds) user;
         };
+
+        unitConfig = systemdLib.requiresAfter [
+          "zfs.target"
+        ];
       };
 
       prowlarr = {
@@ -162,6 +168,7 @@ in
           inherit networks;
           inherit (containerLib.containerIds) user;
         };
+
         unitConfig = afterDownloaders;
       };
 
@@ -188,7 +195,10 @@ in
           inherit (containerLib.containerIds) user;
         };
 
-        unitConfig = afterDownloaders;
+        unitConfig = lib.mkMerge [
+          afterDownloaders
+          (systemdLib.requiresAfter [ "zfs.target" ])
+        ];
       };
 
       radarr = {
@@ -214,7 +224,10 @@ in
           inherit (containerLib.containerIds) user;
         };
 
-        unitConfig = afterDownloaders;
+        unitConfig = lib.mkMerge [
+          afterDownloaders
+          (systemdLib.requiresAfter [ "zfs.target" ])
+        ];
       };
 
       recyclarr = {
@@ -289,6 +302,8 @@ in
           inherit networks;
           inherit (containerLib.containerIds) user;
         };
+
+        unitConfig = systemdLib.requiresAfter [ "zfs.target" ];
       };
 
       audiobookshelf = {
@@ -312,6 +327,8 @@ in
           inherit networks;
           inherit (containerLib.containerIds) user;
         };
+
+        unitConfig = systemdLib.requiresAfter [ "zfs.target" ];
       };
     };
   };

--- a/machines/geekomA5/modules/system/services/data-library/tmpfiles.nix
+++ b/machines/geekomA5/modules/system/services/data-library/tmpfiles.nix
@@ -5,7 +5,7 @@
 }:
 let
   storeRoot = "/mnt/store/data-library";
-  externalRoot = "/mnt/external/data-library";
+  # externalRoot = "/mnt/external/data-library";
 
   foldersToCreate = lib.map (folder: "${storeRoot}/${folder}") [
     "audiobookshelf/config"
@@ -27,35 +27,35 @@ let
     "recyclarr/config"
   ];
 
-  foldersToCreateExternal = lib.map (folder: "${externalRoot}/${folder}") [
-    "downloads/usenet/incomplete"
-    "downloads/usenet/complete/tv"
-    "downloads/usenet/complete/movies"
-    "downloads/usenet/complete/audiobooks"
-    "downloads/usenet/complete/prowlarr"
+  # foldersToCreateExternal = lib.map (folder: "${externalRoot}/${folder}") [
+  #   "downloads/usenet/incomplete"
+  #   "downloads/usenet/complete/tv"
+  #   "downloads/usenet/complete/movies"
+  #   "downloads/usenet/complete/audiobooks"
+  #   "downloads/usenet/complete/prowlarr"
 
-    "downloads/torrent/incomplete"
-    "downloads/torrent/complete/tv"
-    "downloads/torrent/complete/movies"
-    "downloads/torrent/complete/audiobooks"
-    "downloads/torrent/complete/prowlarr"
-    "downloads/torrent/complete/others"
+  #   "downloads/torrent/incomplete"
+  #   "downloads/torrent/complete/tv"
+  #   "downloads/torrent/complete/movies"
+  #   "downloads/torrent/complete/audiobooks"
+  #   "downloads/torrent/complete/prowlarr"
+  #   "downloads/torrent/complete/others"
 
-    "media/tv"
-    "media/movies"
-    "media/music-videos"
-    "media/audiobooks"
+  #   "media/tv"
+  #   "media/movies"
+  #   "media/music-videos"
+  #   "media/audiobooks"
 
-    "share"
-  ];
+  #   "share"
+  # ];
 
   foldersToSetPermissions = [
     storeRoot
   ];
 
-  foldersToSetPermissionsExternal = [
-    externalRoot
-  ];
+  # foldersToSetPermissionsExternal = [
+  #   externalRoot
+  # ];
 
   extraCreateRules = {
     "${storeRoot}/recyclarr/config/configs" = {
@@ -67,12 +67,12 @@ in
   systemd.tmpfiles.settings = {
     "90-data-library-create" = lib.mkMerge [
       (tmpfilesLib.createFoldersUsingDefaultRule foldersToCreate)
-      (tmpfilesLib.createFoldersUsingDefaultMediaRule foldersToCreateExternal)
+      # (tmpfilesLib.createFoldersUsingDefaultMediaRule foldersToCreateExternal)
       extraCreateRules
     ];
     "91-data-library-set" = lib.mkMerge [
       (tmpfilesLib.setPermissionsUsingDefaultRule foldersToSetPermissions)
-      (tmpfilesLib.setPermissionsUsingDefaultMediaRule foldersToSetPermissionsExternal)
+      # (tmpfilesLib.setPermissionsUsingDefaultMediaRule foldersToSetPermissionsExternal)
     ];
   };
 }

--- a/machines/geekomA5/modules/system/services/immich/containers.nix
+++ b/machines/geekomA5/modules/system/services/immich/containers.nix
@@ -124,6 +124,7 @@ in
         unitConfig = systemdLib.requiresAfter [
           containers.immich-valkey.ref
           containers.immich-postgresql.ref
+          "zfs.target"
         ];
       };
     };

--- a/machines/geekomA5/modules/system/services/immich/tmpfiles.nix
+++ b/machines/geekomA5/modules/system/services/immich/tmpfiles.nix
@@ -1,7 +1,7 @@
 { lib, tmpfilesLib, ... }:
 let
   storeRoot = "/mnt/store/immich";
-  externalRoot = "/mnt/external/immich-library";
+  # externalRoot = "/mnt/external/immich-library";
 
   foldersToCreate = lib.map (folder: "${storeRoot}/${folder}") [
     "cache/thumbnails"
@@ -15,7 +15,7 @@ let
 
   foldersToSetPermissions = [
     storeRoot
-    externalRoot
+    # externalRoot
   ];
 in
 {

--- a/machines/geekomA5/modules/system/services/minio/tmpfiles.nix
+++ b/machines/geekomA5/modules/system/services/minio/tmpfiles.nix
@@ -1,19 +1,21 @@
-{ config, tmpfilesLib, ... }:
-let
+# { config, tmpfilesLib, ... }:
+# let
 
-  globalRule = {
-    user = config.users.users.minio.name;
-    group = config.users.users.minio.group;
-    mode = "0755";
-  };
+#   globalRule = {
+#     user = config.users.users.minio.name;
+#     group = config.users.users.minio.group;
+#     mode = "0755";
+#   };
 
-  folders = [
-    "/mnt/external/object-storage/minio"
-  ];
-in
-{
-  systemd.tmpfiles.settings = {
-    "90-minio-create" = tmpfilesLib.applyRuleToFolders { "d" = globalRule; } folders;
-    "91-minio-set" = tmpfilesLib.applyRuleToFolders { "Z" = globalRule; } folders;
-  };
-}
+#   folders = [
+#     "/mnt/external/object-storage/minio"
+#   ];
+# in
+# {
+#   systemd.tmpfiles.settings = {
+#     "90-minio-create" = tmpfilesLib.applyRuleToFolders { "d" = globalRule; } folders;
+#     "91-minio-set" = tmpfilesLib.applyRuleToFolders { "Z" = globalRule; } folders;
+#   };
+# }
+
+_: { }

--- a/machines/geekomA5/modules/system/services/paperless/containers.nix
+++ b/machines/geekomA5/modules/system/services/paperless/containers.nix
@@ -96,6 +96,7 @@ in
         unitConfig = systemdLib.requiresAfter [
           containers.paperless-redis.ref
           containers.paperless-postgresql.ref
+          "zfs.target"
         ];
       };
     };

--- a/machines/geekomA5/modules/system/services/paperless/tmpfiles.nix
+++ b/machines/geekomA5/modules/system/services/paperless/tmpfiles.nix
@@ -1,25 +1,24 @@
 { lib, tmpfilesLib, ... }:
 let
   storeRoot = "/mnt/store/paperless";
-  externalRoot = "/mnt/external/paperless-library";
+  # externalRoot = "/mnt/external/paperless-library";
 
-  foldersToCreate =
-    (lib.map (folder: "${storeRoot}/${folder}") [
-      "data"
+  foldersToCreate = lib.map (folder: "${storeRoot}/${folder}") [
+    "data"
 
-      "export"
+    "export"
 
-      "postgresql"
+    "postgresql"
 
-      "redis"
-    ])
-    ++ (lib.map (folder: "${externalRoot}/${folder}") [
-      "media"
-    ]);
+    "redis"
+  ];
+  # ++ (lib.map (folder: "${externalRoot}/${folder}") [
+  #   "media"
+  # ]);
 
   foldersToSetPermissions = [
     storeRoot
-    externalRoot
+    # externalRoot
   ];
 in
 {


### PR DESCRIPTION
Actually worked this time?
ZFS is not in `fstab` anymore, but it gets imported with `boot.zfs.extraPools` script and then auto-mounted.